### PR TITLE
fix: add google sheets environment variables to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
           DURATION_IN_DAYS: 5
           PAGE_DATA_COUNT: 5
           START_DATE: ${{ secrets.START_DATE }}
+          GOOGLE_SHEETS_ID: ${{ secrets.GOOGLE_SHEETS_ID }}
+          GOOGLE_SHEETS_API_KEY: ${{ secrets.GOOGLE_SHEETS_API_KEY }}
 
       - name: Create assets
         run: |


### PR DESCRIPTION
# Description

The previous PR had failed to deliver the new environment variables in github workflow. Added `GOOGLE_SHEETS_ID` and `GOOGLE_SHEETS_API_KEY` for  #7 .

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I ran `make format` and `make check` commands.
