### PR TITLE
feat: remove hyperlink decoration from username column

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -466,3 +466,14 @@ input:checked + .slider:before {
 .leaderboard__table td:first-child {
   min-width: 180px;
 }
+
+/* Remove hyperlink decoration from usernames in the leaderboard table */
+.leaderboard__table a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.leaderboard__table a:hover {
+  text-decoration: none;
+  color: inherit;
+}


### PR DESCRIPTION
- Added CSS to remove text-decoration from username links in leaderboard table
- Username links now inherit text color instead of default blue
- Maintains accessibility while removing blue hyperlink styling
- Resolves issue #19: Need to Update the style on the username column

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I ran `make format` and `make check` commands.
